### PR TITLE
Feat: 상품 이름 검색 및 정렬, 페이지네이션 기능 추가

### DIFF
--- a/src/main/java/com/cju/shoppingmall/product/controller/ProductSearchController.java
+++ b/src/main/java/com/cju/shoppingmall/product/controller/ProductSearchController.java
@@ -1,0 +1,30 @@
+package com.cju.shoppingmall.product.controller;
+
+import com.cju.shoppingmall.product.entity.Product;
+import com.cju.shoppingmall.product.service.ProductSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Controller
+public class ProductSearchController {
+
+    private final ProductSearchService productSearchService;
+
+    public ProductSearchController(ProductSearchService productSearchService) {
+        this.productSearchService = productSearchService;
+    }
+
+    @GetMapping("/products")
+    public String productList(@RequestParam(required = false) String keyword, Model model) {
+        List<Product> products = productSearchService.searchByName(keyword);
+        model.addAttribute("products", products);
+        model.addAttribute("keyword", keyword);
+        return "screens/product_list";
+    }
+
+}

--- a/src/main/java/com/cju/shoppingmall/product/controller/ProductSearchController.java
+++ b/src/main/java/com/cju/shoppingmall/product/controller/ProductSearchController.java
@@ -2,7 +2,10 @@ package com.cju.shoppingmall.product.controller;
 
 import com.cju.shoppingmall.product.entity.Product;
 import com.cju.shoppingmall.product.service.ProductSearchService;
-import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,10 +23,25 @@ public class ProductSearchController {
     }
 
     @GetMapping("/products")
-    public String productList(@RequestParam(required = false) String keyword, Model model) {
-        List<Product> products = productSearchService.searchByName(keyword);
-        model.addAttribute("products", products);
-        model.addAttribute("keyword", keyword);
+    public String productList(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "16") int size,
+            Model model
+    ) {
+        Pageable pageable = PageRequest.of(
+                page,
+                size,
+                Sort.by(Sort.Direction.DESC, "rating")
+                        .and(Sort.by(Sort.Direction.DESC, "createdAt"))
+        );
+
+        Page<Product> result = productSearchService.searchByName(keyword, pageable);
+
+        model.addAttribute("page", result);                 // 페이지 정보 전체
+        model.addAttribute("products", result.getContent()); // 현재 페이지 상품 리스트
+        model.addAttribute("keyword", keyword);             // 검색어 유지용
+        model.addAttribute("size", size);                   // 페이지 사이즈 유지용
         return "screens/product_list";
     }
 

--- a/src/main/java/com/cju/shoppingmall/product/controller/ProductSearchController.java
+++ b/src/main/java/com/cju/shoppingmall/product/controller/ProductSearchController.java
@@ -11,8 +11,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import java.util.List;
-
 @Controller
 public class ProductSearchController {
 

--- a/src/main/java/com/cju/shoppingmall/product/repository/ProductRepository.java
+++ b/src/main/java/com/cju/shoppingmall/product/repository/ProductRepository.java
@@ -14,5 +14,5 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     List<Product> findTop4ByOrderByCreatedAtDesc();
     List<Product> findTop8ByCreatedAtAfterOrderByCreatedAtDesc(LocalDateTime date);
     List<Product> findTop8ByOrderByCreatedAtDesc();
-
+    List<Product> findByNameContainingIgnoreCase(String keyword);
 }

--- a/src/main/java/com/cju/shoppingmall/product/repository/ProductRepository.java
+++ b/src/main/java/com/cju/shoppingmall/product/repository/ProductRepository.java
@@ -3,6 +3,8 @@ package com.cju.shoppingmall.product.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,5 +16,5 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     List<Product> findTop4ByOrderByCreatedAtDesc();
     List<Product> findTop8ByCreatedAtAfterOrderByCreatedAtDesc(LocalDateTime date);
     List<Product> findTop8ByOrderByCreatedAtDesc();
-    List<Product> findByNameContainingIgnoreCase(String keyword);
+    Page<Product> findByNameContainingIgnoreCase(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/cju/shoppingmall/product/service/ProductSearchService.java
+++ b/src/main/java/com/cju/shoppingmall/product/service/ProductSearchService.java
@@ -1,0 +1,9 @@
+package com.cju.shoppingmall.product.service;
+
+import com.cju.shoppingmall.product.entity.Product;
+
+import java.util.List;
+
+public interface ProductSearchService {
+    List<Product> searchByName(String keyword);
+}

--- a/src/main/java/com/cju/shoppingmall/product/service/ProductSearchService.java
+++ b/src/main/java/com/cju/shoppingmall/product/service/ProductSearchService.java
@@ -1,9 +1,9 @@
 package com.cju.shoppingmall.product.service;
 
 import com.cju.shoppingmall.product.entity.Product;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface ProductSearchService {
-    List<Product> searchByName(String keyword);
+    Page<Product> searchByName(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/cju/shoppingmall/product/service/ProductSearchServiceImpl.java
+++ b/src/main/java/com/cju/shoppingmall/product/service/ProductSearchServiceImpl.java
@@ -2,7 +2,9 @@ package com.cju.shoppingmall.product.service;
 
 import com.cju.shoppingmall.product.entity.Product;
 import com.cju.shoppingmall.product.repository.ProductRepository;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -13,10 +15,11 @@ public class ProductSearchServiceImpl implements ProductSearchService {
         this.productRepository = productRepository;
     }
 
-    public List<Product> searchByName(String keyword) {
-        if (keyword == null || keyword.trim().isEmpty()) {
-            return productRepository.findAll(); // 검색어 없으면 전체
+    @Override
+    public Page<Product> searchByName(String keyword, Pageable pageable) {
+        if (keyword == null || keyword.isBlank()) {
+            return productRepository.findAll(pageable);
         }
-        return productRepository.findByNameContainingIgnoreCase(keyword.trim());
+        return productRepository.findByNameContainingIgnoreCase(keyword.trim(), pageable);
     }
 }

--- a/src/main/java/com/cju/shoppingmall/product/service/ProductSearchServiceImpl.java
+++ b/src/main/java/com/cju/shoppingmall/product/service/ProductSearchServiceImpl.java
@@ -1,0 +1,22 @@
+package com.cju.shoppingmall.product.service;
+
+import com.cju.shoppingmall.product.entity.Product;
+import com.cju.shoppingmall.product.repository.ProductRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ProductSearchServiceImpl implements ProductSearchService {
+    private final ProductRepository productRepository;
+    ProductSearchServiceImpl(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
+
+    public List<Product> searchByName(String keyword) {
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return productRepository.findAll(); // 검색어 없으면 전체
+        }
+        return productRepository.findByNameContainingIgnoreCase(keyword.trim());
+    }
+}

--- a/src/main/java/com/cju/shoppingmall/product/service/ProductSearchServiceImpl.java
+++ b/src/main/java/com/cju/shoppingmall/product/service/ProductSearchServiceImpl.java
@@ -5,10 +5,10 @@ import com.cju.shoppingmall.product.repository.ProductRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.data.domain.Pageable;
-
-import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
 public class ProductSearchServiceImpl implements ProductSearchService {
     private final ProductRepository productRepository;
     ProductSearchServiceImpl(ProductRepository productRepository) {

--- a/src/main/resources/product_data.sql
+++ b/src/main/resources/product_data.sql
@@ -1,24 +1,170 @@
 -- product 테이블 샘플 데이터
 INSERT INTO product (
     id, name, description, thumbnail, base_price, discount_rate,
-    rating,
-    category_id, created_at, created_by, updated_at, updated_by
+    rating, category_id, created_at, created_by, updated_at, updated_by
 ) VALUES
-      (1, '라이트 니트 카디건 #1',
-       '포근하고 가벼운 니트 카디건입니다. 부드러운 소재로 일상복이나 데일리룩에 잘 어울립니다.',
-       'https://picsum.photos/seed/1/800/600',
-       123440, NULL,
-       4.7,
-       (SELECT id FROM category WHERE name='cardigan'),
-       '2025-11-18 12:00:00', 1, '2025-11-18 12:00:00', 1),
+-- 1
+(1, '라이트 니트 카디건 #1',
+ '포근하고 가벼운 니트 카디건입니다. 부드러운 소재로 일상복이나 데일리룩에 잘 어울립니다.',
+ 'https://picsum.photos/seed/1/800/600',
+ 123440, NULL,
+ 4.7,
+ (SELECT id FROM category WHERE name='cardigan'),
+ '2025-11-18 12:00:00', 1, '2025-11-18 12:00:00', 1),
 
-      (2, '클래식 데님 청바지',
-       '편안하고 스타일리시한 기본 청바지입니다.',
-       'https://picsum.photos/seed/2/800/600',
-       45000, 0.05,
-       3.9,
-       (SELECT id FROM category WHERE name='jeans'),
-       '2025-11-17 10:00:00', 2, '2025-11-17 10:00:00', 2);
+-- 2
+(2, '클래식 데님 청바지',
+ '편안하고 스타일리시한 기본 청바지입니다.',
+ 'https://picsum.photos/seed/2/800/600',
+ 45000, 0.05,
+ 3.9,
+ (SELECT id FROM category WHERE name='jeans'),
+ '2025-11-17 10:00:00', 2, '2025-11-17 10:00:00', 2),
+
+-- 3
+(3, '클래식 코튼 셔츠',
+ '사계절 활용 가능한 깔끔한 셔츠입니다.',
+ 'https://picsum.photos/seed/3/800/600',
+ 52000, 0.10,
+ 4.2,
+ (SELECT id FROM category WHERE name='shirts'),
+ '2025-11-18 11:00:00', 2, '2025-11-18 11:00:00', 2),
+
+-- 4
+(4, '클래식 테일러드 자켓',
+ '단정한 핏의 데일리 자켓입니다.',
+ 'https://picsum.photos/seed/4/800/600',
+ 68000, 0.15,
+ 4.6,
+ (SELECT id FROM category WHERE name='jacket'),
+ '2025-11-19 12:00:00', 2, '2025-11-19 12:00:00', 2),
+
+-- 5
+(5, '클래식 라운드 니트',
+ '부드러운 촉감의 기본 니트입니다.',
+ 'https://picsum.photos/seed/5/800/600',
+ 39000, 0.00,
+ 3.8,
+ (SELECT id FROM category WHERE name='knit'),
+ '2025-11-20 13:00:00', 2, '2025-11-20 13:00:00', 2),
+
+-- 6
+(6, '클래식 슬랙스 팬츠',
+ '포멀한 룩에 잘 어울리는 슬랙스입니다.',
+ 'https://picsum.photos/seed/6/800/600',
+ 74000, 0.20,
+ 4.7,
+ (SELECT id FROM category WHERE name='pants'),
+ '2025-11-21 14:00:00', 2, '2025-11-21 14:00:00', 2),
+
+-- 7
+(7, '클래식 울 코트',
+ '유행을 타지 않는 디자인의 코트입니다.',
+ 'https://picsum.photos/seed/7/800/600',
+ 88000, 0.10,
+ 4.9,
+ (SELECT id FROM category WHERE name='coat'),
+ '2025-11-22 15:00:00', 2, '2025-11-22 15:00:00', 2),
+
+-- 8
+(8, '클래식 베이직 티셔츠',
+ '데일리로 입기 좋은 베이직 티셔츠입니다.',
+ 'https://picsum.photos/seed/8/800/600',
+ 32000, 0.00,
+ 3.5,
+ (SELECT id FROM category WHERE name='tshirt'),
+ '2025-11-23 16:00:00', 2, '2025-11-23 16:00:00', 2),
+
+-- 9
+(9, '클래식 데님 스커트',
+ '단정한 실루엣의 데님 스커트입니다.',
+ 'https://picsum.photos/seed/9/800/600',
+ 56000, 0.05,
+ 4.0,
+ (SELECT id FROM category WHERE name='skirt'),
+ '2025-11-24 17:00:00', 2, '2025-11-24 17:00:00', 2),
+
+-- 10
+(10, '클래식 가죽 로퍼',
+ '포멀한 착장에 잘 어울리는 로퍼입니다.',
+ 'https://picsum.photos/seed/10/800/600',
+ 61000, 0.10,
+ 4.3,
+ (SELECT id FROM category WHERE name='shoes'),
+ '2025-11-25 10:00:00', 2, '2025-11-25 10:00:00', 2),
+
+-- 11
+(11, '클래식 니트 가디건',
+ '캐주얼하게 매치하기 좋은 가디건입니다.',
+ 'https://picsum.photos/seed/11/800/600',
+ 43000, 0.00,
+ 3.7,
+ (SELECT id FROM category WHERE name='cardigan'),
+ '2025-11-26 11:00:00', 2, '2025-11-26 11:00:00', 2),
+
+-- 12
+(12, '클래식 더블 자켓',
+ '격식 있는 자리에도 어울리는 재킷입니다.',
+ 'https://picsum.photos/seed/12/800/600',
+ 98000, 0.15,
+ 4.8,
+ (SELECT id FROM category WHERE name='jacket'),
+ '2025-11-27 12:00:00', 2, '2025-11-27 12:00:00', 2),
+
+-- 13
+(13, '클래식 베이직 셔츠',
+ '가볍게 입기 좋은 기본 셔츠입니다.',
+ 'https://picsum.photos/seed/13/800/600',
+ 36000, 0.00,
+ 3.6,
+ (SELECT id FROM category WHERE name='shirts'),
+ '2025-11-28 13:00:00', 2, '2025-11-28 13:00:00', 2),
+
+-- 14
+(14, '클래식 코튼 팬츠',
+ '정갈한 핏의 면 팬츠입니다.',
+ 'https://picsum.photos/seed/14/800/600',
+ 67000, 0.10,
+ 4.1,
+ (SELECT id FROM category WHERE name='pants'),
+ '2025-11-29 14:00:00', 2, '2025-11-29 14:00:00', 2),
+
+-- 15
+(15, '클래식 미디 스커트',
+ '단정한 디자인의 미디 스커트입니다.',
+ 'https://picsum.photos/seed/15/800/600',
+ 54000, 0.05,
+ 3.9,
+ (SELECT id FROM category WHERE name='skirt'),
+ '2025-11-30 15:00:00', 2, '2025-11-30 15:00:00', 2),
+
+-- 16
+(16, '클래식 터틀넥 니트',
+ '겨울철 데일리로 활용하기 좋은 니트입니다.',
+ 'https://picsum.photos/seed/16/800/600',
+ 72000, 0.10,
+ 4.4,
+ (SELECT id FROM category WHERE name='knit'),
+ '2025-12-01 16:00:00', 2, '2025-12-01 16:00:00', 2),
+
+-- 17
+(17, '클래식 울 팬츠',
+ '고급스러운 소재의 울 팬츠입니다.',
+ 'https://picsum.photos/seed/17/800/600',
+ 85000, 0.15,
+ 4.6,
+ (SELECT id FROM category WHERE name='pants'),
+ '2025-12-02 17:00:00', 2, '2025-12-02 17:00:00', 2),
+
+-- 18
+(18, '클래식 싱글 코트',
+ '격식과 캐주얼 모두 어울리는 코트입니다.',
+ 'https://picsum.photos/seed/18/800/600',
+ 99000, 0.20,
+ 4.8,
+ (SELECT id FROM category WHERE name='coat'),
+ '2025-12-03 18:00:00', 2, '2025-12-03 18:00:00', 2);
+
 
 -- product_variant 테이블 샘플 데이터 (외래키 무결성을 위한 추가)
 INSERT INTO product_variant (

--- a/src/main/resources/static/css/product_list.css
+++ b/src/main/resources/static/css/product_list.css
@@ -1,0 +1,9 @@
+main {
+    padding: 24px 24px;
+    box-sizing: border-box;
+}
+@media (min-width: 1200px) {
+    main {
+        padding: 56px 64px;
+    }
+}

--- a/src/main/resources/static/css/product_list.css
+++ b/src/main/resources/static/css/product_list.css
@@ -7,3 +7,47 @@ main {
         padding: 56px 64px;
     }
 }
+.grid-small.grid-4 {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 24px;
+    width: 100%;
+}
+
+.grid-small.grid-4 .card {
+    width: 100%;
+}
+.pagination {
+    display: flex;
+    justify-content: center;   /* 가로 가운데 */
+    align-items: center;
+    gap: 12px;
+    margin: 24px 0 40px;
+    font-size: 15px;
+}
+
+.pagination a {
+    text-decoration: none;
+    color: #444;
+    font-weight: 500;
+}
+
+.pagination a:hover {
+    text-decoration: underline;
+    color: #000;
+}
+
+.pagination a.active {
+    font-weight: 700;
+    color: #000;
+    text-decoration: underline;
+}
+
+.pagination .nav-arrow {
+    font-size: 16px;
+}
+
+.page-numbers {
+    display: flex;
+    gap: 14px;
+}

--- a/src/main/resources/templates/components/_header.html
+++ b/src/main/resources/templates/components/_header.html
@@ -5,8 +5,9 @@
             <img src="/img/logo.png" alt="logo" class="brand-logo"> <span class="brand-name">Furniro</span>
         </a>
         <!-- 검색창 -->
-        <form th:action="@{/search}" method="get" class="search-bar">
-            <input type="text" name="q" placeholder="이름으로 검색" />
+        <form th:action="@{/products}" method="get" class="search-bar">
+            <input type="text" name="keyword" placeholder="이름으로 검색"
+                   th:value="${keyword}" />
             <button type="submit" class="search-btn">&#128269;</button>
         </form>
         <!-- 아이콘 버튼 -->

--- a/src/main/resources/templates/screens/product_list.html
+++ b/src/main/resources/templates/screens/product_list.html
@@ -24,9 +24,7 @@
             </div>
         </section>
 
-        <!-- 📄 페이지네이션 (항상 표시) -->
         <nav class="pagination">
-            <!-- < (맨 앞이면 0으로 고정) -->
             <a class="nav-arrow"
                th:href="@{/products(
                 page=${page.first ? 0 : page.number - 1},
@@ -35,7 +33,6 @@
                 )}">&lt;
             </a>
 
-            <!-- 페이지 번호 -->
             <span class="page-numbers"
                   th:if="${page.totalPages > 0}">
                 <a th:each="i : ${#numbers.sequence(0, page.totalPages - 1)}"
@@ -49,7 +46,6 @@
                 </a>
             </span>
 
-            <!-- > (맨 끝이면 last로 고정) -->
             <a class="nav-arrow"
                th:href="@{/products(
                 page=${page.last ? page.totalPages - 1 : page.number + 1},

--- a/src/main/resources/templates/screens/product_list.html
+++ b/src/main/resources/templates/screens/product_list.html
@@ -1,9 +1,32 @@
-<div th:if="${products == null || #lists.isEmpty(products)}">
-    검색 결과가 없습니다.
-</div>
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <title>상품 리스트</title>
+    <link rel="stylesheet" th:href="@{/css/product_list.css}">
+    <link rel="stylesheet" th:href="@{/css/card.css}">
+    <link rel="stylesheet" th:href="@{/css/footer.css}">
+    <link rel="stylesheet" th:href="@{/css/header.css}">
+</head>
+<body>
+<div th:replace="~{components/_header :: header}"></div>
+    <main>
+        <!-- 검색 결과 없을 때 -->
+        <div th:if="${products == null || #lists.isEmpty(products)}">
+            검색 결과가 없습니다.
+        </div>
 
-<div th:if="${products != null}" th:each="p : ${products}">
-    <div>
-        <span th:text="${p.name}">상품명</span>
-    </div>
-</div>
+        <!-- 검색 결과(상품 목록)도 카드로 -->
+        <section class="grid-small grid-4"
+                 th:if="${products != null && !#lists.isEmpty(products)}">
+            <div th:each="p : ${products}">
+                <div th:replace="~{product/_card :: productCard(p=${p},type='small')}"></div>
+            </div>
+        </section>
+    </main>
+<div th:replace="~{components/_footer}"></div>
+<!-- js file -->
+<script th:src="@{/js/ad.js}"></script>
+
+</body>
+</html>

--- a/src/main/resources/templates/screens/product_list.html
+++ b/src/main/resources/templates/screens/product_list.html
@@ -1,0 +1,9 @@
+<div th:if="${products == null || #lists.isEmpty(products)}">
+    검색 결과가 없습니다.
+</div>
+
+<div th:if="${products != null}" th:each="p : ${products}">
+    <div>
+        <span th:text="${p.name}">상품명</span>
+    </div>
+</div>

--- a/src/main/resources/templates/screens/product_list.html
+++ b/src/main/resources/templates/screens/product_list.html
@@ -23,10 +23,43 @@
                 <div th:replace="~{product/_card :: productCard(p=${p},type='small')}"></div>
             </div>
         </section>
+
+        <!-- 📄 페이지네이션 (항상 표시) -->
+        <nav class="pagination">
+            <!-- < (맨 앞이면 0으로 고정) -->
+            <a class="nav-arrow"
+               th:href="@{/products(
+                page=${page.first ? 0 : page.number - 1},
+                size=${size},
+                keyword=${keyword}
+                )}">&lt;
+            </a>
+
+            <!-- 페이지 번호 -->
+            <span class="page-numbers"
+                  th:if="${page.totalPages > 0}">
+                <a th:each="i : ${#numbers.sequence(0, page.totalPages - 1)}"
+                   th:href="@{/products(
+                        page=${i},
+                        size=${size},
+                        keyword=${keyword}
+                   )}"
+                   th:text="${i + 1}"
+                   th:classappend="${i == page.number} ? 'active' : ''">
+                </a>
+            </span>
+
+            <!-- > (맨 끝이면 last로 고정) -->
+            <a class="nav-arrow"
+               th:href="@{/products(
+                page=${page.last ? page.totalPages - 1 : page.number + 1},
+                size=${size},
+                keyword=${keyword}
+                )}">&gt;
+            </a>
+        </nav>
     </main>
 <div th:replace="~{components/_footer}"></div>
-<!-- js file -->
-<script th:src="@{/js/ad.js}"></script>
 
 </body>
 </html>


### PR DESCRIPTION
[개요]

- 기존 전체 상품 목록 조회 기능에서 상품 이름 기반 검색 기능을 추가
- 검색 결과를 별점(rating) 높은 순으로 정렬. 별점이 같다면 등록일(created_at) 최신 순으로 정렬하여 제공
- 페이지네이션을 적용하여 다수의 상품을 페이지 단위로 조회 가능하도록 개선

[작업 내용]

- 상품 이름(keyword)을 기준으로 검색하는 기능 구현
- Pageable을 활용하여 페이지네이션 처리 (기본 16개씩 조회)
- 검색어가 없을 경우 전체 상품 조회, 있을 경우 검색 결과 조회로 분기 처리
- 조회 시 정렬 조건(별점 → 등록순) 적용